### PR TITLE
Enable configuration cache by upgrading publish plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("signing")
-    id("com.gradle.plugin-publish") version("1.1.0")
+    id("com.gradle.plugin-publish") version("2.0.0")
 }
 
 group = "org.jfxcore"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.configuration-cache=true


### PR DESCRIPTION
The plugin-publish plugin [is now compatible with configuration cache](https://plugins.gradle.org/plugin/com.gradle.plugin-publish). So configuration cache can be enabled.